### PR TITLE
Fix scrollIntoView error

### DIFF
--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -10,7 +10,9 @@ const Page = ({ title, children }: Props) => {
   const pageRef = useRef();
 
   useEffect(() => {
-    pageRef.current.scrollIntoView();
+    if (pageRef.current && typeof pageRef.current.scrollIntoView === 'function') {
+      pageRef.current.scrollIntoView();
+    }
   });
 
   return (


### PR DESCRIPTION
## Summary
- guard the Page component's `scrollIntoView` call

## Testing
- `yarn test src/components/Page/Page.test.js` *(fails: snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6856361b4b108327abf0f6f07825ca63