### PR TITLE
Add default icon test

### DIFF
--- a/src/utils/get-icon.test.js
+++ b/src/utils/get-icon.test.js
@@ -18,4 +18,5 @@ test('getIcon', () => {
   expect(getIcon('codepen')).toEqual(ICONS.CODEPEN);
   expect(getIcon('youtube')).toEqual(ICONS.YOUTUBE);
   expect(getIcon('soundcloud')).toEqual(ICONS.SOUNDCLOUD);
+  expect(getIcon('unknown')).toEqual({});
 });


### PR DESCRIPTION
## Summary
- expand getIcon test to check for unknown icon case

## Testing
- `npx jest src/utils/get-icon.test.js`
- `npm test` *(fails: Jest snapshot and syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68563978f77c8327bb3552f3b0da50a9