### PR TITLE
Add AudioNative component for ElevenLabs text-to-speech integration

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,6 +10,7 @@ module.exports = {
   postsPerPage: 4,
   googleAnalyticsId: 'G-5H8CPHL4SR',
   useKatex: false,
+  elevenLabsProjectId: 'SjZf1f1TP9cUscKEZki4',
   menu: [
     // {
     //   label: 'Articles',

--- a/content/posts/2019-11-17-write-less-code-read-more-career-advice-for-programmers-and-everyone else.md
+++ b/content/posts/2019-11-17-write-less-code-read-more-career-advice-for-programmers-and-everyone else.md
@@ -15,6 +15,7 @@ tags:
   - Career Advice
   - Read More
   - Growth
+audioRecap: "d939997dcea5f564a1ace4880f2393c1c438527124abca30937ab4a8b53fcf05"
 ---
 I started my career as a young developer fresh from my mandatory military service in the IDF. I’d quickly learn, in just a couple of months, practices that I hadn’t acquired in my 3 years of service. One of the first realizations while working post-army was: I can achieve most of the tasks with my current knowledge, but I need to learn new techniques and improve the ones I already have, fast.
 

--- a/src/components/AudioNative/AudioNative.js
+++ b/src/components/AudioNative/AudioNative.js
@@ -1,0 +1,42 @@
+// @flow strict
+import React, { useEffect } from 'react';
+const siteConfig = require('../../../config.js');
+
+type Props = {
+  publicUserId: string,
+};
+
+const SCRIPT_ID = 'elevenlabs-audionative-script';
+
+const AudioNative = ({ publicUserId }: Props) => {
+  useEffect(() => {
+    if (typeof document !== 'undefined' && !document.getElementById(SCRIPT_ID)) {
+      const script = document.createElement('script');
+      script.id = SCRIPT_ID;
+      script.src = 'https://elevenlabs.io/player/audioNativeHelper.js';
+      script.type = 'text/javascript';
+      document.body.appendChild(script);
+    }
+  }, []);
+
+  return (
+    <div
+      id="elevenlabs-audionative-widget"
+      data-height="90"
+      data-width="100%"
+      data-frameborder="no"
+      data-scrolling="no"
+      data-publicuserid={publicUserId}
+      data-playerurl="https://elevenlabs.io/player/index.html"
+      data-projectid={siteConfig.elevenLabsProjectId}
+    >
+      Loading the{' '}
+      <a href="https://elevenlabs.io/text-to-speech" target="_blank" rel="noopener">
+        Elevenlabs Text to Speech
+      </a>{' '}
+      AudioNative Player...
+    </div>
+  );
+};
+
+export default AudioNative;

--- a/src/components/AudioNative/index.js
+++ b/src/components/AudioNative/index.js
@@ -1,0 +1,1 @@
+export { default } from './AudioNative';

--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -3,6 +3,7 @@ import React from 'react';
 import moment from 'moment';
 import { Link } from 'gatsby';
 import { type Edges } from '../../types';
+import AudioNative from '../AudioNative';
 const styles = require('./Feed.module.scss');
 
 type Props = {
@@ -26,6 +27,9 @@ const Feed = ({ edges }: Props) => (
           <Link className={styles['feed__item-title-link']} to={edge.node.fields.slug}>{edge.node.frontmatter.title}</Link>
         </h2>
         <p className={styles['feed__item-description']}>{edge.node.frontmatter.description}</p>
+        {edge.node.frontmatter.audioRecap && (
+          <AudioNative publicUserId={edge.node.frontmatter.audioRecap} />
+        )}
         <Link className={styles['feed__item-readmore']} to={edge.node.fields.slug}>Read</Link>
       </div>
     ))}

--- a/src/components/Feed/Feed.test.js
+++ b/src/components/Feed/Feed.test.js
@@ -20,6 +20,7 @@ describe('Feed', () => {
             date: '2016-09-01',
             description: 'test_0',
             category: 'test_0',
+            audioRecap: 'public-id-0',
             tags: [
               'test-1',
               'test-2'
@@ -45,6 +46,7 @@ describe('Feed', () => {
             date: '2016-09-01',
             description: 'test_1',
             category: 'test_1',
+            audioRecap: 'public-id-1',
             tags: [
               'test-1',
               'test-2'

--- a/src/components/Feed/__snapshots__/Feed.test.js.snap
+++ b/src/components/Feed/__snapshots__/Feed.test.js.snap
@@ -45,6 +45,28 @@ exports[`Feed renders correctly 1`] = `
     >
       test_0
     </p>
+    <div
+      data-frameborder="no"
+      data-height="90"
+      data-playerurl="https://elevenlabs.io/player/index.html"
+      data-projectid="SjZf1f1TP9cUscKEZki4"
+      data-publicuserid="public-id-0"
+      data-scrolling="no"
+      data-width="100%"
+      id="elevenlabs-audionative-widget"
+    >
+      Loading the
+       
+      <a
+        href="https://elevenlabs.io/text-to-speech"
+        rel="noopener"
+        target="_blank"
+      >
+        Elevenlabs Text to Speech
+      </a>
+       
+      AudioNative Player...
+    </div>
     <a
       className="feed__item-readmore"
       href="/test_0"
@@ -93,6 +115,28 @@ exports[`Feed renders correctly 1`] = `
     >
       test_1
     </p>
+    <div
+      data-frameborder="no"
+      data-height="90"
+      data-playerurl="https://elevenlabs.io/player/index.html"
+      data-projectid="SjZf1f1TP9cUscKEZki4"
+      data-publicuserid="public-id-1"
+      data-scrolling="no"
+      data-width="100%"
+      id="elevenlabs-audionative-widget"
+    >
+      Loading the
+       
+      <a
+        href="https://elevenlabs.io/text-to-speech"
+        rel="noopener"
+        target="_blank"
+      >
+        Elevenlabs Text to Speech
+      </a>
+       
+      AudioNative Player...
+    </div>
     <a
       className="feed__item-readmore"
       href="/test_1"

--- a/src/templates/index-template.js
+++ b/src/templates/index-template.js
@@ -64,6 +64,7 @@ export const query = graphql`
             date
             category
             description
+            audioRecap
           }
         }
       }


### PR DESCRIPTION
## Summary
- Add AudioNative React component with ElevenLabs integration
- Integrate audio player in blog post feed for posts with audioRecap metadata
- Update GraphQL queries and tests to support audio recap functionality

## Test plan
- [ ] Verify AudioNative component renders correctly in Feed
- [ ] Test script loading and audio player functionality
- [ ] Run existing tests to ensure no regressions
- [ ] Verify posts without audioRecap still display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)